### PR TITLE
Update Fork Master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "richvigorito/laravel-lumens-annotations",
+    "name": "oregoncatholicpress/laravel-lumens-annotations",
     "description": "Route and event binding annotations for Laravel Lumen",
     "keywords": ["laravel","lumen","route","routes","router","annotations","event","event binding"],
     "license": "MIT",


### PR DESCRIPTION
For some reason Master wasn't kept up to date, which is causing bugs in the OCP fork. This brings the 4.0 changes into master and changes the name of the fork to ocp.